### PR TITLE
SASS-11777: Create API service/controller/routing to hook into connector

### DIFF
--- a/app/controllers/CreateOrUpdateOtherReliefsController.scala
+++ b/app/controllers/CreateOrUpdateOtherReliefsController.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import controllers.predicates.AuthorisedAction
+import models.otherReliefs.CreateOrUpdateOtherReliefsModel
+import play.api.libs.json.{JsSuccess, Json}
+import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import services.CreateOrUpdateOtherReliefsService
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+
+class CreateOrUpdateOtherReliefsController @Inject()(createOrUpdateOtherReliefsService: CreateOrUpdateOtherReliefsService,
+                                                     cc: ControllerComponents,
+                                                     authorisedAction: AuthorisedAction)
+                                                    (implicit ec: ExecutionContext) extends BackendController(cc) {
+
+  def createOrUpdateOtherReliefs(nino: String, taxYear: Int): Action[AnyContent] = authorisedAction.async { implicit user =>
+    user.request.body.asJson.map(_.validate[CreateOrUpdateOtherReliefsModel]) match {
+      case Some(JsSuccess(model, _)) =>
+        createOrUpdateOtherReliefsService.createOrUpdateOtherReliefs(nino, taxYear, model).map {
+          case Right(_) => NoContent
+          case Left(errorModel) => Status(errorModel.status)(Json.toJson(errorModel.toJson))
+        }
+      case _ => Future.successful(BadRequest)
+    }
+  }
+
+}

--- a/app/services/CreateOrUpdateOtherReliefsService.scala
+++ b/app/services/CreateOrUpdateOtherReliefsService.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import connectors.CreateOrUpdateOtherReliefsConnector
+import connectors.parsers.CreateOrUpdateOtherReliefsParser.CreateOrUpdateOtherReliefsResponse
+import models.otherReliefs.CreateOrUpdateOtherReliefsModel
+import uk.gov.hmrc.http.HeaderCarrier
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.Future
+
+@Singleton
+class CreateOrUpdateOtherReliefsService @Inject()(createOrUpdateOtherReliefsConnector: CreateOrUpdateOtherReliefsConnector) {
+
+  def createOrUpdateOtherReliefs(nino: String, taxYear: Int, createOrUpdateOtherReliefsModel: CreateOrUpdateOtherReliefsModel)
+                                    (implicit hc: HeaderCarrier): Future[CreateOrUpdateOtherReliefsResponse] = {
+    createOrUpdateOtherReliefsConnector.createOrUpdateOtherReliefs(nino, taxYear, createOrUpdateOtherReliefsModel)
+  }
+
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -3,6 +3,9 @@ GET        /income-tax/insurance-policies/income/:nino/:taxYear              con
 PUT        /income-tax/insurance-policies/income/:nino/:taxYear              controllers.CreateOrAmendInsurancePoliciesController.createOrAmendInsurancePolicies(nino:String, taxYear: Int)
 DELETE     /income-tax/insurance-policies/income/:nino/:taxYear              controllers.DeleteInsurancePoliciesController.deleteInsurancePoliciesData(nino: String, taxYear: Int)
 
+## IF #1632 - v0.1.0 ###
+PUT        /income-tax/reliefs/other/:nino/:taxYear                          controllers.CreateOrUpdateOtherReliefsController.createOrUpdateOtherReliefs(nino:String, taxYear: Int)
+
 GET        /:taxYear/tasks/:nino                                             controllers.CommonTaskListController.getCommonTaskList(taxYear: Int, nino: String)
 
 ### IF #1794 - v9.1.0 ###

--- a/it/test/connectors/CreateOrUpdateOtherReliefsConnectorISpec.scala
+++ b/it/test/connectors/CreateOrUpdateOtherReliefsConnectorISpec.scala
@@ -22,12 +22,10 @@ import helpers.WiremockSpec
 import models._
 import models.otherReliefs._
 import org.scalatestplus.play.PlaySpec
-import play.api.Configuration
 import play.api.http.Status._
 import play.api.libs.json.{JsObject, Json}
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, HeaderNames, SessionId}
-import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import utils.TaxYearUtils.convertStringTaxYear
 
 class CreateOrUpdateOtherReliefsConnectorISpec extends PlaySpec with WiremockSpec {
@@ -58,10 +56,10 @@ class CreateOrUpdateOtherReliefsConnectorISpec extends PlaySpec with WiremockSpe
     nonDeductableLoanInterest = None,
     payrollGiving = None,
     qualifyingDistributionRedemptionOfSharesAndSecurities = None,
-    maintenancePayments = Some(Seq()),
-    postCessationTradeReliefAndCertainOtherLosses = Some(Seq()),
+    maintenancePayments = Some(Seq.empty),
+    postCessationTradeReliefAndCertainOtherLosses = Some(Seq.empty),
     annualPaymentsMade = None,
-    qualifyingLoanInterestPayments = Some(Seq()),
+    qualifyingLoanInterestPayments = Some(Seq.empty),
   )
 
   val modelEmpty: JsObject = Json.obj()

--- a/test/controllers/CreateOrUpdateOtherReliefsControllerSpec.scala
+++ b/test/controllers/CreateOrUpdateOtherReliefsControllerSpec.scala
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import connectors.parsers.CreateOrUpdateOtherReliefsParser.CreateOrUpdateOtherReliefsResponse
+import models._
+import models.otherReliefs._
+import org.scalamock.handlers.CallHandler4
+import play.api.http.Status._
+import play.api.libs.json.Json
+import play.api.mvc.{AnyContentAsEmpty, Result}
+import play.api.test.FakeRequest
+import services.CreateOrUpdateOtherReliefsService
+import testUtils.TestSuite
+import uk.gov.hmrc.http.{HeaderCarrier, SessionKeys}
+
+import scala.concurrent.Future
+
+class CreateOrUpdateOtherReliefsControllerSpec extends TestSuite {
+
+  val serviceMock: CreateOrUpdateOtherReliefsService = mock[CreateOrUpdateOtherReliefsService]
+  val controller = new CreateOrUpdateOtherReliefsController(serviceMock, mockControllerComponents, authorisedAction)
+
+  val serviceUnavailableModel: ErrorModel =
+    ErrorModel(SERVICE_UNAVAILABLE, ErrorBodyModel("SERVICE_UNAVAILABLE", "The service is currently unavailable"))
+  val badRequestModel: ErrorModel = ErrorModel(BAD_REQUEST, ErrorBodyModel("BAD_REQUEST", "The supplied NINO is invalid"))
+  val internalServerErrorModel: ErrorModel =
+    ErrorModel(INTERNAL_SERVER_ERROR, ErrorBodyModel("INTERNAL_SERVER_ERROR", "There has been an unexpected error"))
+  val unprocessableEntityModel: ErrorModel =
+    ErrorModel(UNPROCESSABLE_ENTITY, ErrorBodyModel("UNPROCESSABLE_ENTITY", "The remote endpoint has indicated that for given income source type, message payload is incorrect."))
+
+
+  val nino = "nino"
+  val taxYear = 2023
+  val mtditid = "1234567890"
+
+  val model: CreateOrUpdateOtherReliefsModel = CreateOrUpdateOtherReliefsModel(
+    nonDeductableLoanInterest = Some(NonDeductableLoanInterestModel(Some("RefNo13254687"), 123.45)),
+    payrollGiving = Some(PayrollGivingModel(Some("RefNo13254687"), 123.46)),
+    qualifyingDistributionRedemptionOfSharesAndSecurities = Some(QualifyingDistributionModel(Some("RefNo13254687"), 123.47)),
+    maintenancePayments = Some(Seq(MaintenancePaymentsModel(Some("RefNo13254687"), Some("Jane Doe"), Some("01-01-2000"), 123.48))),
+    postCessationTradeReliefAndCertainOtherLosses = Some(Seq(PostCessationTradeReliefModel(Some("RefNo13254687"), Some("Monsters Inc"), Some("01-01-2025"), Some("Power Distribution"), Some("Cash"), 123.49))),
+    annualPaymentsMade = Some(AnnualPaymentsMadeModel(Some("RefNo13254687"), 123.50)),
+    qualifyingLoanInterestPayments = Some(Seq(QualifyingLoanInterestPaymentsModel(Some("RefNo13254687"), Some("Bank"), 123.51))),
+  )
+
+  override val fakeRequestWithMtditid: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("PUT", "/")
+    .withHeaders("MTDITID" -> mtditid, SessionKeys.sessionId -> "some-session-id")
+
+  ".putOtherReliefs" should {
+
+    "Return a 204 NO Content response with valid putOtherReliefs" in {
+      val serviceResult = Right(true)
+
+      def serviceCallMock(): CallHandler4[String, Int, CreateOrUpdateOtherReliefsModel, HeaderCarrier, Future[CreateOrUpdateOtherReliefsResponse]] =
+        (serviceMock.createOrUpdateOtherReliefs(_: String, _: Int, _: CreateOrUpdateOtherReliefsModel)(_: HeaderCarrier))
+          .expects(nino, taxYear, model, *)
+          .returning(Future.successful(serviceResult))
+
+      val result: Future[Result] = {
+        mockAuth()
+        serviceCallMock()
+        controller.createOrUpdateOtherReliefs(nino, taxYear)(fakeRequestWithMtditid.withJsonBody(Json.toJson(model)))
+      }
+      status(result) mustBe NO_CONTENT
+    }
+
+    "Return a 400 BAD_REQUEST response with invalid putOtherReliefs" in {
+      val result = {
+        mockAuth()
+        controller.createOrUpdateOtherReliefs(nino, taxYear)()(fakeRequestWithMtditid.withJsonBody(Json.toJson("InvalidOtherReliefsModel")))
+      }
+
+      status(result) mustBe BAD_REQUEST
+    }
+
+    "return a Left response" when {
+
+      def mockCreateOrUpdateOtherReliefsWithError(errorModel: ErrorModel):
+        CallHandler4[String, Int, CreateOrUpdateOtherReliefsModel, HeaderCarrier, Future[CreateOrUpdateOtherReliefsResponse]] = {
+          (serviceMock.createOrUpdateOtherReliefs(_: String, _: Int, _: CreateOrUpdateOtherReliefsModel)(_: HeaderCarrier))
+            .expects(nino, taxYear, *, *)
+            .returning(Future.successful(Left(errorModel)))
+      }
+
+      "the service returns a BAD_REQUEST" in {
+        val result = {
+          mockAuth()
+          mockCreateOrUpdateOtherReliefsWithError(badRequestModel)
+          controller.createOrUpdateOtherReliefs(nino, taxYear)(fakeRequestWithMtditid.withJsonBody(Json.toJson(model)))
+        }
+        status(result) mustBe BAD_REQUEST
+      }
+
+      "the service returns a UNPROCESSABLE_ENTITY" in {
+        val result = {
+          mockAuth()
+          mockCreateOrUpdateOtherReliefsWithError(unprocessableEntityModel)
+          controller.createOrUpdateOtherReliefs(nino, taxYear)(fakeRequestWithMtditid.withJsonBody(Json.toJson(model)))
+        }
+        status(result) mustBe UNPROCESSABLE_ENTITY
+      }
+
+      "the service returns a INTERNAL_SERVER_ERROR" in {
+        val result = {
+          mockAuth()
+          mockCreateOrUpdateOtherReliefsWithError(internalServerErrorModel)
+          controller.createOrUpdateOtherReliefs(nino, taxYear)(fakeRequestWithMtditid.withJsonBody(Json.toJson(model)))
+        }
+        status(result) mustBe INTERNAL_SERVER_ERROR
+      }
+
+      "the service returns a SERVICE_UNAVAILABLE" in {
+        val result = {
+          mockAuth()
+          mockCreateOrUpdateOtherReliefsWithError(serviceUnavailableModel)
+          controller.createOrUpdateOtherReliefs(nino, taxYear)(fakeRequestWithMtditid.withJsonBody(Json.toJson(model)))
+        }
+        status(result) mustBe SERVICE_UNAVAILABLE
+      }
+    }
+  }
+
+}

--- a/test/models/otherReliefs/CreateOrUpdateOtherReliefsModelSpec.scala
+++ b/test/models/otherReliefs/CreateOrUpdateOtherReliefsModelSpec.scala
@@ -87,10 +87,10 @@ class CreateOrUpdateOtherReliefsModelSpec extends TestSuite {
     None,
     None,
     None,
-    Some(Seq()),
-    Some(Seq()),
+    Some(Seq.empty),
+    Some(Seq.empty),
     None,
-    Some(Seq())
+    Some(Seq.empty)
   )
 
   val validJson: JsObject = Json.obj(


### PR DESCRIPTION
## Description

- added other reliefs controller/service + routes
- Added controller spec

## Curl Request
```
curl --request PUT \
  --url http://localhost:10004/income-tax-additional-information/income-tax/reliefs/other/AA123456B/2025 \
  --header 'authorization: {{BEARER}}' \
  --header 'content-type: application/json' \
  --header 'mtditid: 1234567890' \
  --header 'sessionid: {{SESSIONID}}' \
  --data '{
  "nonDeductableLoanInterest": {
    "customerReference": "RefNo13254687",
    "reliefClaimed": 123.45
  },
  "payrollGiving": {
    "customerReference": "RefNo13254687",
    "reliefClaimed": 123.46
  },
  "qualifyingDistributionRedemptionOfSharesAndSecurities": {
    "customerReference": "RefNo13254687",
    "amount": 123.47
  },
  "maintenancePayments": [
    {
      "customerReference": "RefNo13254687",
      "exSpouseName": "Jane Doe",
      "exSpouseDateOfBirth": "01-01-2000",
      "amount": 123.48
    }
  ],
  "postCessationTradeReliefAndCertainOtherLosses": [
    {
      "customerReference": "RefNo13254687",
      "businessName": "Monsters Inc",
      "dateBusinessCeased": "01-01-2025",
      "natureOfTrade": "Power Distribution",
      "incomeSource": "Cash",
      "amount": 123.49
    }
  ],
  "annualPaymentsMade": {
    "customerReference": "RefNo13254687",
    "reliefClaimed": 123.5
  },
  "qualifyingLoanInterestPayments": [
    {
      "customerReference": "RefNo13254687",
      "lenderName": "Bank",
      "reliefClaimed": 123.51
    }
  ]
}'
```
Here's a curl request for testing manually locally. Just swap out the sessionId and Bearer for your own